### PR TITLE
Fix session duration

### DIFF
--- a/metadata/config/service.json
+++ b/metadata/config/service.json
@@ -8,5 +8,5 @@
   "phaseText": "Service phase text goes here",
   "serviceEmailAddress": "form-builder@digital.justice.gov.uk",
   "serviceUrl": "page.start",
-  "sessionDuration": 30
+  "sessionDuration": 60
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-components",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Components as JSON Schemas, Nunjucks templates, Nunjucks helpers, and utilities for Form Builder",
   "scripts": {
     "build": "cross-env NODE_ENV=production concurrently -r \"npm run gulp -- build\" \"webpack\"",


### PR DESCRIPTION
## Description

On https://github.com/ministryofjustice/fb-runner-node/blob/master/lib/middleware/user-session/user-session.js#L79 the value that is returning is from a config on this repo, so 
changing the number here makes the maxAge of the session to be the right amount expected by us.