### PR TITLE
Fix/security upload issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-components",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Components as JSON Schemas, Nunjucks templates, Nunjucks helpers, and utilities for Form Builder",
   "scripts": {
     "build": "cross-env NODE_ENV=production concurrently -r \"npm run gulp -- build\" \"webpack\"",

--- a/specifications/uploadCheck/templates/nunjucks/uploadCheck.njk
+++ b/specifications/uploadCheck/templates/nunjucks/uploadCheck.njk
@@ -4,7 +4,7 @@
       <ul>
       {% for uploadDescription in data.uploadDescriptions %}
         <li class="govuk-body-l">
-          {{ uploadDescription }}
+          <strong>{{ uploadDescription }}</strong>
         </li>
       {% endfor %}
       </ul>

--- a/specifications/uploadCheck/templates/nunjucks/uploadCheck.njk
+++ b/specifications/uploadCheck/templates/nunjucks/uploadCheck.njk
@@ -4,7 +4,7 @@
       <ul>
       {% for uploadDescription in data.uploadDescriptions %}
         <li class="govuk-body-l">
-          {{ uploadDescription | safe }}
+          {{ uploadDescription }}
         </li>
       {% endfor %}
       </ul>


### PR DESCRIPTION
[Trello card](https://trello.com/c/8QXpkEsp/719-issue-with-the-upload-a-file-component-bug-score-33)

## Context

The upload description field was marked as safe - that means that any HTML will be rendered on the page. The problem is that this field comes from user input which causes a huge security flaw (cross site scripting) on runner.


## Next steps

- [ ] Merge runner PR