### PR TITLE
Changed the default email address.

### DIFF
--- a/metadata/config/service.json
+++ b/metadata/config/service.json
@@ -6,7 +6,7 @@
   "name": "Service name goes here",
   "phase": "alpha",
   "phaseText": "Service phase text goes here",
-  "serviceEmailAddress": "moj-online@digital.justice.gov.uk",
+  "serviceEmailAddress": "moj-forms@digital.justice.gov.uk",
   "serviceUrl": "page.start",
   "sessionDuration": 20
 }


### PR DESCRIPTION
The team had rebranded but not the email address used to 'send
from' to the new address created. This change updates the default email address
from moj-online to moj-forms.

https://trello.com/c/L2TUpOkp