### PR TITLE
Only surface production dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "production"
   reviewers:
   - mattempty
   - brenetic


### PR DESCRIPTION
[Trello](https://trello.com/c/VSRSkkfz/2187-github-security-risks)
We are currently receiving alerts for devDependencies.
Configure dependabot alerts to only warn about production dependencies.